### PR TITLE
Upgrade go version used to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/elnormous/contenttype
 
-go 1.13
+go 1.14


### PR DESCRIPTION
Upgrade the go version to 1.14 to resolve usage of http.Header.Values
not existing until 1.14.

Closes #7 